### PR TITLE
Added cluster-config and console-link to 201 BOM

### DIFF
--- a/boms/software/gitops/201-gitops-bootstrap.yaml
+++ b/boms/software/gitops/201-gitops-bootstrap.yaml
@@ -21,3 +21,5 @@ spec:
       variables:
         - name: create_webhook
           value: true
+    - name: gitops-cluster-config
+    - name: gitops-console-link-job 


### PR DESCRIPTION
Signed-off-by: Ramya Raghuveera <ramragh1@in.ibm.com>
cluster-config and console-link need to be added to 201 BOM for CloudNative Toolkit (220-dev-tools) to install competely.