### PR TITLE
Fix invalid environment variables in docker launch

### DIFF
--- a/common-files/launch.sh
+++ b/common-files/launch.sh
@@ -65,9 +65,9 @@ if [[ -f "credentials.properties" ]]; then
     CLEAN="$(echo $line | sed 's/export //' )"
 
     #parse key-value pairs
-    IFS="\=" read -a tokens <<< ${CLEAN}
-    KEY="${tokens[0]}"
-    VALUE="${tokens[1]}"
+    IFS=$' =' read -a TOKENS <<< ${CLEAN}
+    KEY="${TOKENS[0]}"
+    VALUE="${TOKENS[1]}"
 
     # don't add an empty key
     if [[ -n "${KEY}" ]]; then

--- a/common-files/launch.sh
+++ b/common-files/launch.sh
@@ -65,11 +65,14 @@ if [[ -f "credentials.properties" ]]; then
     CLEAN="$(echo $line | sed 's/export //' )"
 
     #parse key-value pairs
-    TOKENS=(${CLEAN//\"/ })
-    KEY="${TOKENS[0]%?}"
-    VALUE="${TOKENS[1]}"
+    IFS="\=" read -a tokens <<< ${CLEAN}
+    KEY="${tokens[0]}"
+    VALUE="${tokens[1]}"
 
-    ENV_VARS="-e $KEY=$VALUE $ENV_VARS"
+    # don't add an empty key
+    if [[ -n "${KEY}" ]]; then
+      ENV_VARS="-e $KEY=$VALUE $ENV_VARS"
+    fi
   done <<< "$props"
 fi
 

--- a/common-files/launch.sh
+++ b/common-files/launch.sh
@@ -65,9 +65,7 @@ if [[ -f "credentials.properties" ]]; then
     CLEAN="$(echo $line | sed 's/export //' )"
 
     #parse key-value pairs
-    IFS=$' =' read -a TOKENS <<< ${CLEAN}
-    KEY="${TOKENS[0]}"
-    VALUE="${TOKENS[1]}"
+    IFS=' =' read -r KEY VALUE <<< ${CLEAN//\"/ }
 
     # don't add an empty key
     if [[ -n "${KEY}" ]]; then


### PR DESCRIPTION
Add check to KEY to ensure non-empty. Update parse method.

Fixes #198 