### PR TITLE
Updates for apply and launch scripts

### DIFF
--- a/common-files/apply-all-terragrunt-variables.sh
+++ b/common-files/apply-all-terragrunt-variables.sh
@@ -50,12 +50,12 @@ function process_variable () {
   value="${environment_variable}"
   if [[ "${sensitive}" == "true" ]] && [[ -f "${CREDENTIALS_FILE}" ]]; then
     value=$(cat "${CREDENTIALS_FILE}" | NAME="${name}" ${YQ} e -o json '.variables[] | select(.name == env(NAME)) | .value' - | jq -c -r '.')
-    if [[ "${value}" == "null" ]]; then
+    if [[ -z "${value}" ]]; then
       value="${environment_variable}"
     fi
   elif [[ "${sensitive}" != "true" ]] && [[ -f "${VARIABLES_FILE}" ]]; then
     value=$(cat "${VARIABLES_FILE}" | NAME="${name}" ${YQ} e -o json '.variables[] | select(.name == env(NAME)) | .value' - | jq -c -r '.')
-    if [[ "${value}" == "null" ]]; then
+    if [[ -z "${value}" ]]; then
       value="${environment_variable}"
     fi
   fi

--- a/common-files/apply-terragrunt-variables.sh
+++ b/common-files/apply-terragrunt-variables.sh
@@ -49,12 +49,12 @@ else
     value="${environment_variable}"
     if [[ "${sensitive}" == "true" ]] && [[ -f "${CREDENTIALS_FILE}" ]]; then
       value=$(cat "${CREDENTIALS_FILE}" | NAME="${name}" ${YQ} e -o json '.variables[] | select(.name == env(NAME)) | .value' - | jq -c -r '.')
-      if [[ "${value}" == "null" ]]; then
+      if [[ -z "${value}" ]]; then
         value="${environment_variable}"
       fi
     elif [[ "${sensitive}" != "true" ]] && [[ -f "${VARIABLES_FILE}" ]]; then
       value=$(cat "${VARIABLES_FILE}" | NAME="${name}" ${YQ} e -o json '.variables[] | select(.name == env(NAME)) | .value' - | jq -c -r '.')
-      if [[ "${value}" == "null" ]]; then
+      if [[ -z "${value}" ]]; then
         value="${environment_variable}"
       fi
     fi

--- a/common-files/launch.sh
+++ b/common-files/launch.sh
@@ -49,7 +49,7 @@ then
 fi
 
 
-DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools:v1.2-v2.4.0"
+DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools:v1.2-v2.4.1"
 #IBM DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools-ibmcloud:v1.2-v0.6.0"
 #AWS DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools-aws:v1.2-v0.5.0"
 #AZURE DOCKER_IMAGE="quay.io/cloudnativetoolkit/cli-tools-azure:v1.2-v0.6.0"


### PR DESCRIPTION
Update `apply.sh` logic for handling environment variables intended for non-sensitive variables. Fixes #235 

Update `cli-tools` tag in common `launch.sh` to current version. Fixes https://github.com/cloud-native-toolkit/iascable/issues/290